### PR TITLE
fix(mailer): pass event to SUCT mail

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -189,7 +189,7 @@ exports.addEvent = async (req, res) => {
             subject: 'A event was submitted.',
             template: 'summeruniversity_submitted.html',
             parameters: {
-                event: req.event
+                event
             }
         });
     });
@@ -309,7 +309,7 @@ exports.editEvent = async (req, res) => {
                 subject: 'A event was submitted.',
                 template: 'summeruniversity_submitted.html',
                 parameters: {
-                    event: req.event
+                    event
                 }
             });
         }


### PR DESCRIPTION
The first one is a bug which I noticed while testing the dispatcher, the event is apparently in `req.body`. The second one is just for consistency with the other email.