### PR TITLE
fix: use core login instead of user login

### DIFF
--- a/lib/applications.js
+++ b/lib/applications.js
@@ -71,8 +71,9 @@ exports.createApplication = async (req, res) => {
             }
         });
 
+        const adminToken = await core.getAdminToken();
         req.event.organizers = await Promise.all(req.event.organizers.map((organizer) =>
-            core.fetchUser(organizer, req.headers['x-auth-token'])));
+            core.fetchUser(organizer, adminToken)));
 
         // Sending the mail to the organizers
         await mailer.sendMail({
@@ -150,8 +151,9 @@ exports.updateApplication = async (req, res) => {
             }
         });
 
+        const adminToken = await core.getAdminToken();
         req.event.organizers = await Promise.all(req.event.organizers.map((organizer) =>
-            core.fetchUser(organizer, req.headers['x-auth-token'])));
+            core.fetchUser(organizer, adminToken)));
 
         // Sending the mail to the organizers
         await mailer.sendMail({
@@ -255,7 +257,8 @@ exports.setApplicationStatus = async (req, res) => {
         // Updating application in a transaction, so if mail sending fails, the update would be reverted.
         await req.application.update({ status: req.body.status }, { transaction: t });
 
-        const notificationEmail = (await core.fetchUser(req.application, req.headers['x-auth-token'])).notification_email;
+        const adminToken = await core.getAdminToken();
+        const notificationEmail = (await core.fetchUser(req.application, adminToken)).notification_email;
 
         // Sending the mail to a user.
         await mailer.sendMail({

--- a/lib/core.js
+++ b/lib/core.js
@@ -150,9 +150,32 @@ const getBodyUsersForPermission = async (permission, bodyId) => {
     return membersResponse.data;
 };
 
+const getAdminToken = async () => {
+    // Getting access and refresh token using admin credentials.
+    const authRequest = await makeRequest({
+        url: config.core.url + ':' + config.core.port + '/login',
+        method: 'POST',
+        body: {
+            username: config.core.user.login,
+            password: config.core.user.password
+        }
+    });
+
+    if (typeof authRequest !== 'object') {
+        throw new Error('Malformed response when fetching auth request: ' + authRequest);
+    }
+
+    if (!authRequest.success) {
+        throw new Error('Error fetching auth request: ' + JSON.stringify(authRequest));
+    }
+
+    return authRequest.access_token;
+};
+
 module.exports = {
     fetchUser,
     fetchApplicationUser,
     fetchBody,
-    getBodyUsersForPermission
+    getBodyUsersForPermission,
+    getAdminToken
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -193,8 +193,9 @@ exports.addEvent = async (req, res) => {
         // Creating the event in a transaction, so if mail sending fails, the update would be reverted.
         await event.save({ transaction: t });
 
+        const adminToken = await core.getAdminToken();
         event.organizers = await Promise.all(event.organizers.map((organizer) =>
-            core.fetchUser(organizer, req.headers['x-auth-token'])));
+            core.fetchUser(organizer, adminToken)));
 
         // Sending the mail to a user.
         await mailer.sendMail({
@@ -302,8 +303,9 @@ exports.editEvent = async (req, res) => {
         // Updating the event in a transaction, so if mail sending fails, the update would be reverted.
         await event.update(data, { transaction: t });
 
+        const adminToken = await core.getAdminToken();
         data.organizers = await Promise.all(data.organizers.map((organizer) =>
-            core.fetchUser(organizer, req.headers['x-auth-token'])));
+            core.fetchUser(organizer, adminToken)));
 
         // Sending the mail to a user.
         await mailer.sendMail({
@@ -356,8 +358,9 @@ exports.setApprovalStatus = async (req, res) => {
 
     await sequelize.transaction(async (t) => {
         const event = req.event;
+        const adminToken = await core.getAdminToken();
         event.organizers = await Promise.all(event.organizers.map((organizer) =>
-            core.fetchUser(organizer, req.headers['x-auth-token'])));
+            core.fetchUser(organizer, adminToken)));
 
         await req.event.update({ status: req.body.status }, { transaction: t });
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -194,12 +194,12 @@ exports.addEvent = async (req, res) => {
         await event.save({ transaction: t });
 
         const adminToken = await core.getAdminToken();
-        event.organizers = await Promise.all(event.organizers.map((organizer) =>
+        const organizers = await Promise.all(event.organizers.map((organizer) =>
             core.fetchUser(organizer, adminToken)));
 
         // Sending the mail to a user.
         await mailer.sendMail({
-            to: event.organizers.map((organizer) => organizer.notification_email),
+            to: organizers.map((organizer) => organizer.notification_email),
             subject: 'The event was created',
             template: 'summeruniversity_event_created.html',
             parameters: {


### PR DESCRIPTION
This removes the need for users to have `global:view:member` to change application status or similar actions